### PR TITLE
Journalist can login to create article

### DIFF
--- a/cypress/fixtures/journalist_can_login.json
+++ b/cypress/fixtures/journalist_can_login.json
@@ -1,0 +1,11 @@
+{
+  "status": "success",
+  "data": {
+    "id": 1,
+    "email": "journalist@mail.com",
+    "provider": "email",
+    "uid": "journalist@mail.com",
+    "allow_password_change": false,
+    "role": "journalist"
+  }
+}

--- a/cypress/fixtures/registered_user_can_not_log_in.json
+++ b/cypress/fixtures/registered_user_can_not_log_in.json
@@ -1,0 +1,12 @@
+{
+  "status": "success",
+  "data": {
+    "id": 2,
+    "email": "registered@user.com",
+    "provider": "email",
+    "uid": "registered@user.com",
+    "name": "user",
+    "allow_password_change": false,
+    "role": "registered user"
+  }
+}

--- a/cypress/integration/journalistCanCreateAnArticle.feature.js
+++ b/cypress/integration/journalistCanCreateAnArticle.feature.js
@@ -21,44 +21,28 @@ describe("Journalist can create an article", () => {
       cy.get("[data-cy='submit-btn']").contains("Submit").click();
     });
   });
-
-  it("is expected to successfully fill in ", () => {
-    cy.route({
-      method: "POST",
-      url: "http://localhost:3000/api/articles",
-      response: { message: "Your article was successfully created" },
-    });
-    cy.get("[data-cy='article-form']").within(() => {
-      cy.get("[data-cy='title-field']").type("Article Title");
-      cy.get("[data-cy='lead-field']").type("Article Lead");
-      cy.get("[data-cy='body-field']").type("Article Body");
-      cy.get('[data-cy="categories-dropdown"]').select("Culture");
-      cy.get("[data-cy='create-article-button']").click();
-      cy.get("[data-cy='api-response-success-message']").should(
-        "contain",
-        "Your article was successfully created"
-      );
+  describe("successfully", () => {
+    it("when all fields are filled in ", () => {
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/articles",
+        response: { message: "Your article was successfully created" },
+      });
+      cy.get("[data-cy='article-form']").within(() => {
+        cy.get("[data-cy='title-field']").type("Article Title");
+        cy.get("[data-cy='lead-field']").type("Article Lead");
+        cy.get("[data-cy='body-field']").type("Article Body");
+        cy.get('[data-cy="categories-dropdown"]').select("Culture");
+        cy.get("[data-cy='create-article-button']").click();
+        cy.get("[data-cy='api-response-success-message']").should(
+          "contain",
+          "Your article was successfully created"
+        );
+      });
     });
   });
 
-  describe("Sad path: Journalist can not create an article", () => {
-    beforeEach(() => {
-      cy.server();
-      cy.route({
-        method: "POST",
-        url: "http://localhost:3000/api/auth/sign_in",
-        response: "fixture:journalist_can_login.json",
-        headers: {
-          uid: "journalist@mail.com",
-        },
-      });
-      cy.route({
-        method: "GET",
-        url: "http://localhost:3000/api/auth/validate_token**",
-        response: "fixture:journalist_can_login.json",
-      });
-    });
-
+  describe("unsuccessfully", () => {
     it("when title is not filled in ", () => {
       cy.route({
         method: "POST",

--- a/cypress/integration/journalistCanCreateAnArticle.feature.js
+++ b/cypress/integration/journalistCanCreateAnArticle.feature.js
@@ -1,15 +1,33 @@
-/* eslint-disable no-undef */
 describe("Journalist can create an article", () => {
-  before(() => {
+  beforeEach(() => {
     cy.server();
+    cy.route({
+      method: "POST",
+      url: "http://localhost:3000/api/auth/sign_in",
+      response: "fixture:journalist_can_login.json",
+      headers: {
+        uid: "journalist@mail.com",
+      },
+    });
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/auth/validate_token**",
+      response: "fixture:journalist_can_login.json",
+    });
+    cy.visit("/");
+    cy.get("[data-cy='login-form']").within(() => {
+      cy.get("[data-cy='email']").type("journalist@mail.com");
+      cy.get("[data-cy='password']").type("password");
+      cy.get("[data-cy='submit-btn']").contains("Submit").click();
+    });
+  });
+
+  it("is expected to successfully fill in ", () => {
     cy.route({
       method: "POST",
       url: "http://localhost:3000/api/articles",
       response: { message: "Your article was successfully created" },
     });
-    cy.visit("/");
-  });
-  it("is expected to successfully fill in ", () => {
     cy.get("[data-cy='article-form']").within(() => {
       cy.get("[data-cy='title-field']").type("Article Title");
       cy.get("[data-cy='lead-field']").type("Article Lead");
@@ -22,11 +40,25 @@ describe("Journalist can create an article", () => {
       );
     });
   });
+
   describe("Sad path: Journalist can not create an article", () => {
     beforeEach(() => {
       cy.server();
-      cy.visit("/");
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/auth/sign_in",
+        response: "fixture:journalist_can_login.json",
+        headers: {
+          uid: "journalist@mail.com",
+        },
+      });
+      cy.route({
+        method: "GET",
+        url: "http://localhost:3000/api/auth/validate_token**",
+        response: "fixture:journalist_can_login.json",
+      });
     });
+
     it("when title is not filled in ", () => {
       cy.route({
         method: "POST",

--- a/cypress/integration/journalistCanLoginAndSeeArticleForm.feature.js
+++ b/cypress/integration/journalistCanLoginAndSeeArticleForm.feature.js
@@ -16,64 +16,69 @@ describe("Journalist can login to see article form", () => {
     });
     cy.visit("/");
   });
-  it("successfully with correct credentials", () => {
-    cy.get("[data-cy='login-form']").within(() => {
-      cy.get("[data-cy='email']").type("journalist@mail.com");
-      cy.get("[data-cy='password']").type("password");
-      cy.get("[data-cy='submit-btn']").contains("Submit").click();
-    });
-    cy.get("[data-cy='header-user-email']").should(
-      "contain",
-      "Meow! Welcome back journalist@mail.com"
-    );
-    cy.get("[data-cy='article-form']").should("exist");
-  });
-  it("unsuccessfully with wrong credentials", () => {
-    cy.route({
-      method: "POST",
-      url: "http://localhost:3000/api/auth/sign_in",
-      status: "401",
-      response: {
-        errors: ["Invalid login credentials. Please try again."],
-        success: false,
-      },
-    });
-    cy.get("[data-cy='login-form']").within(() => {
-      cy.get("[data-cy='email']").type("journalist@mail.com");
-      cy.get("[data-cy='password']").type("wrongpassword");
-      cy.get("[data-cy='submit-btn']").contains("Submit").click();
-      cy.get("[data-cy='error-message']").contains(
-        "Invalid login credentials. Please try again."
+  describe("successfully", () => {
+    it("with correct credentials", () => {
+      cy.get("[data-cy='login-form']").within(() => {
+        cy.get("[data-cy='email']").type("journalist@mail.com");
+        cy.get("[data-cy='password']").type("password");
+        cy.get("[data-cy='submit-btn']").contains("Submit").click();
+      });
+      cy.get("[data-cy='header-user-email']").should(
+        "contain",
+        "Meow! Welcome back journalist@mail.com"
       );
+      cy.get("[data-cy='article-form']").should("exist");
     });
-    cy.get("[data-cy='header-user-email']").contains(
-      "Woof! You're not logged in yet."
-    );
-    cy.get("[data-cy='article-form']").should("not.exist");
   });
-  it("sad path: unsuccessfully with right credentials but not an journalist", () => {
-    cy.route({
-      method: "POST",
-      url: "http://localhost:3000/api/auth/sign_in",
-      response: "fixture:registered_user_can_not_log_in.json",
-    });
-    cy.route({
-      method: "GET",
-      url: "http://localhost:3000/api/auth/validate_token**",
-      response: "fixture:registered_user_can_not_log_in.json",
-    });
-    cy.visit("/");
-    cy.get("[data-cy='login-form']").within(() => {
-      cy.get("[data-cy='email']").type("registered@user.com");
-      cy.get("[data-cy='password']").type("password");
-      cy.get("[data-cy='submit-btn']").contains("Submit").click();
-      cy.get("[data-cy='error-message']").contains(
-        "You are not authorized to be here"
+  describe("unsuccessfully", () => {
+    it("with wrong credentials", () => {
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/auth/sign_in",
+        status: "401",
+        response: {
+          errors: ["Invalid login credentials. Please try again."],
+          success: false,
+        },
+      });
+      cy.get("[data-cy='login-form']").within(() => {
+        cy.get("[data-cy='email']").type("journalist@mail.com");
+        cy.get("[data-cy='password']").type("wrongpassword");
+        cy.get("[data-cy='submit-btn']").contains("Submit").click();
+        cy.get("[data-cy='error-message']").contains(
+          "Invalid login credentials. Please try again."
+        );
+      });
+      cy.get("[data-cy='header-user-email']").contains(
+        "Woof! You're not logged in yet."
       );
+      cy.get("[data-cy='article-form']").should("not.exist");
     });
-    cy.get("[data-cy='header-user-email']").contains(
-      "Woof! You're not logged in yet."
-    );
-    cy.get("[data-cy='article-form']").should("not.exist");
+
+    it("with right credentials but not an journalist", () => {
+      cy.route({
+        method: "POST",
+        url: "http://localhost:3000/api/auth/sign_in",
+        response: "fixture:registered_user_can_not_log_in.json",
+      });
+      cy.route({
+        method: "GET",
+        url: "http://localhost:3000/api/auth/validate_token**",
+        response: "fixture:registered_user_can_not_log_in.json",
+      });
+      cy.visit("/");
+      cy.get("[data-cy='login-form']").within(() => {
+        cy.get("[data-cy='email']").type("registered@user.com");
+        cy.get("[data-cy='password']").type("password");
+        cy.get("[data-cy='submit-btn']").contains("Submit").click();
+        cy.get("[data-cy='error-message']").contains(
+          "You are not authorized to be here"
+        );
+      });
+      cy.get("[data-cy='header-user-email']").contains(
+        "Woof! You're not logged in yet."
+      );
+      cy.get("[data-cy='article-form']").should("not.exist");
+    });
   });
 });

--- a/cypress/integration/journalistCanLoginAndSeeArticleForm.feature.js
+++ b/cypress/integration/journalistCanLoginAndSeeArticleForm.feature.js
@@ -1,4 +1,4 @@
-describe("Journalist can login", () => {
+describe("Journalist can login to see article form", () => {
   beforeEach(() => {
     cy.server();
     cy.route({
@@ -25,8 +25,9 @@ describe("Journalist can login", () => {
     });
     cy.get("[data-cy='header-user-email']").should(
       "contain",
-      "Logged in as journalist@mail.com"
+      "Meow! Welcome back journalist@mail.com"
     );
+
     cy.get("[data-cy='article-form']").should("exist");
   });
 
@@ -49,7 +50,7 @@ describe("Journalist can login", () => {
         "Invalid login credentials. Please try again."
       );
     });
-    cy.get("[data-cy='header-user-email']").contains("You're not logged in.");
+    cy.get("[data-cy='header-user-email']").contains("Woof! You're not logged in.");
     cy.get("[data-cy='article-form']").should("not.exist");
   });
 
@@ -74,7 +75,7 @@ describe("Journalist can login", () => {
         "You are not authorized to be here"
       );
     });
-    cy.get("[data-cy='header-user-email']").contains("You're not logged in.");
+    cy.get("[data-cy='header-user-email']").contains("Woof! You're not logged in.");
     cy.get("[data-cy='article-form']").should("not.exist");
   });
 });

--- a/cypress/integration/journalistCanLoginAndSeeArticleForm.feature.js
+++ b/cypress/integration/journalistCanLoginAndSeeArticleForm.feature.js
@@ -16,7 +16,6 @@ describe("Journalist can login to see article form", () => {
     });
     cy.visit("/");
   });
-
   it("successfully with correct credentials", () => {
     cy.get("[data-cy='login-form']").within(() => {
       cy.get("[data-cy='email']").type("journalist@mail.com");
@@ -27,10 +26,8 @@ describe("Journalist can login to see article form", () => {
       "contain",
       "Meow! Welcome back journalist@mail.com"
     );
-
     cy.get("[data-cy='article-form']").should("exist");
   });
-
   it("unsuccessfully with wrong credentials", () => {
     cy.route({
       method: "POST",
@@ -41,7 +38,6 @@ describe("Journalist can login to see article form", () => {
         success: false,
       },
     });
-
     cy.get("[data-cy='login-form']").within(() => {
       cy.get("[data-cy='email']").type("journalist@mail.com");
       cy.get("[data-cy='password']").type("wrongpassword");
@@ -50,10 +46,11 @@ describe("Journalist can login to see article form", () => {
         "Invalid login credentials. Please try again."
       );
     });
-    cy.get("[data-cy='header-user-email']").contains("Woof! You're not logged in yet.");
+    cy.get("[data-cy='header-user-email']").contains(
+      "Woof! You're not logged in yet."
+    );
     cy.get("[data-cy='article-form']").should("not.exist");
   });
-
   it("sad path: unsuccessfully with right credentials but not an journalist", () => {
     cy.route({
       method: "POST",
@@ -66,7 +63,6 @@ describe("Journalist can login to see article form", () => {
       response: "fixture:registered_user_can_not_log_in.json",
     });
     cy.visit("/");
-
     cy.get("[data-cy='login-form']").within(() => {
       cy.get("[data-cy='email']").type("registered@user.com");
       cy.get("[data-cy='password']").type("password");
@@ -75,7 +71,9 @@ describe("Journalist can login to see article form", () => {
         "You are not authorized to be here"
       );
     });
-    cy.get("[data-cy='header-user-email']").contains("Woof! You're not logged in yet.");
+    cy.get("[data-cy='header-user-email']").contains(
+      "Woof! You're not logged in yet."
+    );
     cy.get("[data-cy='article-form']").should("not.exist");
   });
 });

--- a/cypress/integration/journalistCanLoginAndSeeArticleForm.feature.js
+++ b/cypress/integration/journalistCanLoginAndSeeArticleForm.feature.js
@@ -50,7 +50,7 @@ describe("Journalist can login to see article form", () => {
         "Invalid login credentials. Please try again."
       );
     });
-    cy.get("[data-cy='header-user-email']").contains("Woof! You're not logged in.");
+    cy.get("[data-cy='header-user-email']").contains("Woof! You're not logged in yet.");
     cy.get("[data-cy='article-form']").should("not.exist");
   });
 
@@ -75,7 +75,7 @@ describe("Journalist can login to see article form", () => {
         "You are not authorized to be here"
       );
     });
-    cy.get("[data-cy='header-user-email']").contains("Woof! You're not logged in.");
+    cy.get("[data-cy='header-user-email']").contains("Woof! You're not logged in yet.");
     cy.get("[data-cy='article-form']").should("not.exist");
   });
 });

--- a/cypress/integration/journalistCanLoginToCreateArticles.feature.js
+++ b/cypress/integration/journalistCanLoginToCreateArticles.feature.js
@@ -1,0 +1,77 @@
+describe("Journalist can login to create articles", () => {
+  beforeEach(() => {
+    cy.server();
+    cy.route({
+      method: "POST",
+      url: "http://localhost:3000/api/auth/sign_in",
+      response: "fixture:journalist_can_login.json",
+      headers: {
+        uid: "journalist@mail.com",
+      },
+    });
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/auth/validate_token**",
+      response: "fixture:journalist_can_login.json",
+    });
+    cy.visit("/");
+  });
+
+  it("successfully with correct credentials", () => {
+    cy.get("[data-cy='login-form']").within(() => {
+      cy.get("[data-cy='email']").type("journalist@mail.com");
+      cy.get("[data-cy='password']").type("password");
+      cy.get("[data-cy='submit-btn']").contains("Submit").click();
+    });
+    cy.get("[data-cy='header-user-email']").should(
+      "contain",
+      "Logged in as journalist@mail.com"
+    );
+  });
+
+  it("unsuccessfully with wrong credentials", () => {
+    cy.route({
+      method: "POST",
+      url: "http://localhost:3000/api/auth/sign_in",
+      status: "401",
+      response: {
+        errors: ["Invalid login credentials. Please try again."],
+        success: false,
+      },
+    });
+
+    cy.get("[data-cy='login-form']").within(() => {
+      cy.get("[data-cy='email']").type("journalist@mail.com");
+      cy.get("[data-cy='password']").type("wrongpassword");
+      cy.get("[data-cy='submit-btn']").contains("Submit").click();
+      cy.get("[data-cy='error-message']").contains(
+        "Invalid login credentials. Please try again."
+      );
+    });
+    cy.get("[data-cy='header-user-email']").contains("You're not logged in.");
+  });
+
+  it("sad path: unsuccessfully with right credentials but not an journalist", () => {
+    cy.route({
+      method: "POST",
+      url: "http://localhost:3000/api/auth/sign_in",
+      response: "fixture:registered_user_can_not_log_in.json",
+    });
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/auth/validate_token**",
+      response: "fixture:registered_user_can_not_log_in.json",
+    });
+    cy.visit("/");
+
+    cy.get("[data-cy='login-form']").within(() => {
+      cy.get("[data-cy='email']").type("registered@user.com");
+      cy.get("[data-cy='password']").type("password");
+      cy.get("[data-cy='submit-btn']").contains("Submit").click();
+      cy.get("[data-cy='error-message']").contains(
+        "You are not authorized to be here"
+      );
+    });
+    cy.get("[data-cy='header-user-email']").contains("You're not logged in.");
+  });
+});

--- a/cypress/integration/journalistCanLoginToCreateArticles.feature.js
+++ b/cypress/integration/journalistCanLoginToCreateArticles.feature.js
@@ -1,4 +1,4 @@
-describe("Journalist can login to create articles", () => {
+describe("Journalist can login", () => {
   beforeEach(() => {
     cy.server();
     cy.route({
@@ -27,6 +27,7 @@ describe("Journalist can login to create articles", () => {
       "contain",
       "Logged in as journalist@mail.com"
     );
+    cy.get("[data-cy='article-form']").should("exist");
   });
 
   it("unsuccessfully with wrong credentials", () => {
@@ -49,6 +50,7 @@ describe("Journalist can login to create articles", () => {
       );
     });
     cy.get("[data-cy='header-user-email']").contains("You're not logged in.");
+    cy.get("[data-cy='article-form']").should("not.exist");
   });
 
   it("sad path: unsuccessfully with right credentials but not an journalist", () => {
@@ -73,5 +75,6 @@ describe("Journalist can login to create articles", () => {
       );
     });
     cy.get("[data-cy='header-user-email']").contains("You're not logged in.");
+    cy.get("[data-cy='article-form']").should("not.exist");
   });
 });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "axios": "^0.21.1",
+    "j-tockauth": "^1.2.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-redux": "^7.2.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import LoginForm from "./components/LoginForm";
 import Header from "./components/Header";
 
 const App = () => {
-  const currentUser = useSelector((state) => state.currentUser);
+  const currentUser = useSelector(state => state.currentUser);
   return (
     <>
       <Header />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,15 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import CreateArticleForm from "./components/CreateArticleForm";
 import LoginForm from "./components/LoginForm";
+import Header from "./components/Header";
 
 const App = () => {
+  const currentUser = useSelector((state) => state.currentUser);
   return (
     <>
-      <LoginForm />
-      <CreateArticleForm />
+      <Header />
+      {currentUser ? <CreateArticleForm /> : <LoginForm />}
     </>
   );
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,14 @@
-import React from 'react'
-import CreateArticleForm from './components/CreateArticleForm'
+import React from "react";
+import CreateArticleForm from "./components/CreateArticleForm";
+import LoginForm from "./components/LoginForm";
 
 const App = () => {
   return (
     <>
+      <LoginForm />
       <CreateArticleForm />
     </>
-  )
-}
+  );
+};
 
-export default App
+export default App;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,18 +1,26 @@
-import React from 'react'
+import React from "react";
 import { useSelector } from "react-redux";
+import { Segment, Icon } from "semantic-ui-react";
 
 const Header = () => {
-  const currentUser = useSelector(state => state.currentUser)
+  const currentUser = useSelector((state) => state.currentUser);
   return (
-    <div>
-      <h2 data-cy="header-user-email">
-        {currentUser
-          ? `Meow! Welcome back ${currentUser.uid}`
-          : "Woof! You're not logged in."
-        }
-      </h2>
-    </div>
-  )
-}
+    <Segment.Group horizontal>
+      <Segment>
+        <h3 data-cy="header-user-email">
+          {currentUser
+            ? `Meow! Welcome back ${currentUser.uid}`
+            : "Woof! You're not logged in yet."}
+        </h3>
+      </Segment>
+      <Segment>
+        <h1>Kitty News ADMIN PAGE</h1>
+      </Segment>
+      <Segment>
+          <Icon name="paw" size="big" color="pink"/>
+      </Segment>
+    </Segment.Group>
+  );
+};
 
-export default Header
+export default Header;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -7,8 +7,8 @@ const Header = () => {
     <div>
       <h2 data-cy="header-user-email">
         {currentUser
-          ? `Logged in as ${currentUser.uid}`
-          : "You're not logged in."
+          ? `Meow! Welcome back ${currentUser.uid}`
+          : "Woof! You're not logged in."
         }
       </h2>
     </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { useSelector } from "react-redux";
+
+const Header = () => {
+  const currentUser = useSelector(state => state.currentUser)
+  return (
+    <div>
+      <h2 data-cy="header-user-email">
+        {currentUser
+          ? `Logged in as ${currentUser.uid}`
+          : "You're not logged in."
+        }
+      </h2>
+    </div>
+  )
+}
+
+export default Header

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, Icon, Segment, Form, Message } from 'semantic-ui-react';
-import { performAuthentication } from '../modules/Authentication';
+import performAuthentication from '../modules/Authentication';
 
 const LoginForm = () => {
   const dispatch = useDispatch();

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Button, Icon, Segment, Form, Message } from 'semantic-ui-react';
+// import { performAuthentication } from '../modules/auth';
+
+const LoginForm = () => {
+  const dispatch = useDispatch();
+  const errorMessage = useSelector(state => state.errorMessage);
+
+  return (
+    <Segment placeholder>
+      <Form
+        className="loginForm"
+        data-cy="login-form"
+        // onSubmit={(event) => performAuthentication(event, dispatch)}
+      >
+        <Form.Input
+          icon="at"
+          type="text"
+          label="Email"
+          name="email"
+          data-cy="email"
+          placeholder="Email"
+          iconPosition="left"
+        />
+        <Form.Input
+          icon="key"
+          type="password"
+          label="Password"
+          name="password"
+          data-cy="password"
+          placeholder="password"
+          iconPosition="left"
+        />
+
+        <Button data-cy="submit-btn" icon labelPosition="left">
+          <Icon name="user"></Icon>
+          Submit
+        </Button>
+        {errorMessage &&
+        <Message data-cy="error-message">{errorMessage}</Message> }
+      </Form>
+    </Segment>
+  );
+};
+
+export default LoginForm;

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, Icon, Segment, Form, Message } from 'semantic-ui-react';
-// import { performAuthentication } from '../modules/auth';
+import { performAuthentication } from '../modules/Authentication';
 
 const LoginForm = () => {
   const dispatch = useDispatch();
@@ -12,7 +12,7 @@ const LoginForm = () => {
       <Form
         className="loginForm"
         data-cy="login-form"
-        // onSubmit={(event) => performAuthentication(event, dispatch)}
+        onSubmit={(event) => performAuthentication(event, dispatch)}
       >
         <Form.Input
           icon="at"

--- a/src/modules/ArticlesServices.js
+++ b/src/modules/ArticlesServices.js
@@ -3,15 +3,22 @@ import axios from "axios";
 const ArticlesServices = {
   async create(event, dispatch) {
     event.preventDefault();
+    let headers = JSON.parse(localStorage.getItem("J-tockAuth-Storage"));
     try {
-      let response = await axios.post("/articles", {
-        article: {
-          title: event.target.title.value,
-          lead: event.target.lead.value,
-          body: event.target.body.value,
-          category_id: parseInt(event.target.categories.value),
+      let response = await axios.post(
+        "/articles",
+        {
+          article: {
+            title: event.target.title.value,
+            lead: event.target.lead.value,
+            body: event.target.body.value,
+            category_id: parseInt(event.target.categories.value),
+          },
         },
-      });
+        {
+          header: headers,
+        }
+      );
       dispatch({
         type: "SET_ARTICLE_MESSAGE",
         payload: response.data.message,

--- a/src/modules/ArticlesServices.js
+++ b/src/modules/ArticlesServices.js
@@ -16,7 +16,7 @@ const ArticlesServices = {
           },
         },
         {
-          header: headers,
+          headers: headers,
         }
       );
       dispatch({

--- a/src/modules/Authentication.js
+++ b/src/modules/Authentication.js
@@ -1,0 +1,36 @@
+import JtockAuth from "j-tockauth";
+
+const auth = new JtockAuth({
+  host: "http://localhost:3000",
+  prefixUrl: "/api",
+});
+
+const performAuthentication = async (event, dispatch) => {
+  try {
+    debugger
+    event.preventDefault();
+    let response = await auth.signIn(
+      event.target.email.value,
+      event.target.password.value
+    );
+    if (response.data.role === "journalist") {
+      dispatch({
+        type: "SET_CURRENT_USER",
+        payload: response.data,
+      });
+    } else {
+      dispatch({
+        type: "SET_ERROR_MESSAGE",
+        payload: "You are not authorized to be here",
+      });
+      localStorage.removeItem("J-tockAuth-Storage");
+    }
+  } catch (error) {
+    console.log(error);
+    dispatch({
+      type: "SET_ERROR_MESSAGE",
+      payload: error.response.data.errors[0],
+    });
+  }
+};
+export { performAuthentication };

--- a/src/modules/Authentication.js
+++ b/src/modules/Authentication.js
@@ -7,7 +7,6 @@ const auth = new JtockAuth({
 
 const performAuthentication = async (event, dispatch) => {
   try {
-    debugger
     event.preventDefault();
     let response = await auth.signIn(
       event.target.email.value,
@@ -33,4 +32,4 @@ const performAuthentication = async (event, dispatch) => {
     });
   }
 };
-export { performAuthentication };
+export default performAuthentication;

--- a/src/state/reducers/rootReducer.js
+++ b/src/state/reducers/rootReducer.js
@@ -4,13 +4,19 @@ const rootReducer = (state = {}, action) => {
       return {
         ...state,
         createArticleMessage: action.payload,
-        errorMessage: ""
+        errorMessage: "",
       };
     case "SET_ERROR_MESSAGE":
       return {
         ...state,
         errorMessage: action.payload,
-        createArticleMessage: ""
+        createArticleMessage: "",
+      };
+    case "SET_CURRENT_USER":
+      return {
+        ...state,
+        currentUser: action.payload,
+        auth: { message: "You are logged in", status: true },
       };
     default:
       return state;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1711,6 +1711,13 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
   integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
+"@types/axios@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@types/axios/-/axios-0.14.0.tgz#ec2300fbe7d7dddd7eb9d3abf87999964cafce46"
+  integrity sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=
+  dependencies:
+    axios "*"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
@@ -2584,19 +2591,27 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
   integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios-mock-adapter@^1.17.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz#9d72e321a6c5418e1eff067aa99761a86c5188a4"
+  integrity sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==
   dependencies:
-    follow-redirects "1.5.10"
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.3"
 
-axios@^0.21.1:
+axios@*, axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
+
+axios@^0.19.0, axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -5135,7 +5150,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -6206,6 +6221,11 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
+is-buffer@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
+
 is-callable@^1.1.4, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
@@ -6572,6 +6592,15 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+j-tockauth@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/j-tockauth/-/j-tockauth-1.2.7.tgz#46877df372db18e23fa94004659de4581d32d7e4"
+  integrity sha512-MqEgrxLB17ABUBb9GpapaNYXnnTYCeT9LGzWI3FisTQHJ8voT8sDA7Ds2dKse2e+xxZDum2Md4vRpobRVYwf/Q==
+  dependencies:
+    "@types/axios" "^0.14.0"
+    axios "^0.19.0"
+    axios-mock-adapter "^1.17.0"
 
 jest-changed-files@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
[Journalist has to be logged in to create an article ADMIN](https://www.pivotaltracker.com/story/show/176339855)
## User Story
```
As a journalist,
In order to restrict the access of creating articles,
I would like to be able to have a login functionality.
```
## Changes proposed in this pull request:
* Creating login test and creating two fixture file with journalist and registered user
* Created a login form
* Authentication action I rootReducer
* Creating authentication model
* Adding ternary operator in app.jsx so that article form only show if user is logged in.
## What I have learned working on this feature:
* j-tock auth
* importance of checking initializers in API
## Packages/Gems added
* j-tock auth
## Screenshots (Client)
![Skärmavbild 2021-01-10 kl  21 09 01](https://user-images.githubusercontent.com/72305485/104134140-2b2d9f80-5388-11eb-814e-20513d542bdc.png)
